### PR TITLE
insert numbers by position order instead of selected order

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,24 +23,27 @@
         "Other"
     ],
     "engines": {
-        "vscode": "^1.0.0"
+        "vscode": "^1.1.18"
     },
     "activationEvents": [
         "onCommand:extension.insertNumbers"
     ],
     "main": "./out/src/extension",
     "contributes": {
-        "commands": [{
-            "command": "extension.insertNumbers",
-            "title": "Insert Numbers"
-        }],
-        
-        "keybindings": [{
-            "command": "extension.insertNumbers",
-            "key": "ctrl+alt+n",
-            "mac": "cmd+alt+n",
-            "when": "editorTextFocus"
-        }]
+        "commands": [
+            {
+                "command": "extension.insertNumbers",
+                "title": "Insert Numbers"
+            }
+        ],
+        "keybindings": [
+            {
+                "command": "extension.insertNumbers",
+                "key": "ctrl+alt+n",
+                "mac": "cmd+alt+n",
+                "when": "editorTextFocus"
+            }
+        ]
     },
     "scripts": {
         "vscode:prepublish": "node ./node_modules/vscode/bin/compile",

--- a/src/NumInserter.ts
+++ b/src/NumInserter.ts
@@ -88,7 +88,7 @@ export class NumInserter
     {
         let textEditor = vscode.window.activeTextEditor;
         
-        const selections : vscode.Selection[] = textEditor.selections;
+        const selections : vscode.Selection[] = this.quickSort(textEditor.selections);
         
         const formatStr = settings.formatStr;
         const start = settings.start;
@@ -109,6 +109,36 @@ export class NumInserter
                 }
             }
         ) 
+    }
+
+    private quickSort(selections : vscode.Selection[]) : vscode.Selection[]
+    {
+        let middleIndex : number = selections.length >> 1;
+        if (selections.length <= 1) {
+            return selections;
+        }
+        let middle : vscode.Selection = selections[middleIndex];
+        let left : vscode.Selection[] = [];
+        let right : vscode.Selection[] = [];
+        for (var i=0; i<selections.length; i++){
+            if(i==middleIndex){
+                continue;
+            }
+            let current : vscode.Selection = selections[i];
+            if (current.start.line < middle.start.line) {
+                left.push(current);
+            } else if (current.start.line > middle.start.line) {
+                right.push(current);
+            } else {
+                if (current.start.character <= middle.start.character) {
+                    left.push(current);
+                } else {
+                    right.push(current);
+                }
+            }
+
+        }
+        return this.quickSort(left).concat([middle], this.quickSort(right));
     }
     
     private parseUserInput(input : string) : IInsertSettngs


### PR DESCRIPTION
I found when my selection began at the random position, the beginning of inserting number is also along with the position, that's make me confused.
I think it is better to insert by the editor position order instead of my selections order.